### PR TITLE
Add simulated SLAM writer and update pose interface

### DIFF
--- a/simulated_slam_writer.py
+++ b/simulated_slam_writer.py
@@ -1,0 +1,37 @@
+import airsim
+import time
+import os
+import argparse
+
+
+def main(rate: float) -> None:
+    client = airsim.MultirotorClient()
+    client.confirmConnection()
+
+    os.makedirs("slam", exist_ok=True)
+    interval = 1.0 / rate if rate > 0 else 0.05
+
+    while True:
+        pose = client.simGetVehiclePose()
+        x = pose.position.x_val
+        y = pose.position.y_val
+        z = pose.position.z_val
+        _, _, yaw = airsim.to_eularian_angles(pose.orientation)
+        timestamp = time.time()
+        with open("slam/latest_pose.txt", "w") as f:
+            f.write(f"{x:.3f},{y:.3f},{z:.3f},{yaw:.3f},{timestamp:.3f}")
+        time.sleep(interval)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Write AirSim ground-truth pose to a file to simulate SLAM"
+    )
+    parser.add_argument(
+        "--rate",
+        type=float,
+        default=20.0,
+        help="update rate in Hz (default: 20)",
+    )
+    args = parser.parse_args()
+    main(args.rate)

--- a/slam/slam_interface.py
+++ b/slam/slam_interface.py
@@ -1,130 +1,32 @@
-"""Interface for retrieving the drone pose.
+"""Simple interface for retrieving the drone pose from a SLAM file."""
+from __future__ import annotations
 
-The primary source of pose data is an external SLAM process which writes the
-latest estimate to ``slam/latest_pose.txt``. If the file cannot be read or
-contains stale data, the code falls back to AirSim's ground-truth pose when
-available. A short rolling average is applied to smooth pose estimates.
-"""
-from typing import Deque, Optional, Tuple
-from collections import deque
-import logging
 import os
-import time
-import socket
-
-import airsim
+from typing import Tuple
 
 
-_CLIENT: Optional[airsim.MultirotorClient]
-try:
-    _CLIENT = airsim.MultirotorClient()
-    _CLIENT.confirmConnection()
-except Exception as exc:  # pragma: no cover - connection failure is non-fatal
-    logging.warning("Failed to connect to AirSim for fallback poses: %s", exc)
-    _CLIENT = None
+# path to the pose file written by ``simulated_slam_writer.py``
+POSE_FILE = os.path.join(os.path.dirname(__file__), "latest_pose.txt")
 
-# Keep a short history to optionally smooth pose estimates
-_POSE_BUFFER: Deque[Tuple[float, float, float, float]] = deque(maxlen=5)
-
-# path to the shared pose file written by the external SLAM system
-_POSE_FILE = os.path.join(os.path.dirname(__file__), 'latest_pose.txt')
-
-# ignore pose entries older than this many seconds
-_POSE_TIMEOUT = 1.0
-
-
-def _average_pose() -> Tuple[float, float, float, float]:
-    """Return the mean pose from the buffer."""
-    n = len(_POSE_BUFFER)
-    sx = sum(p[0] for p in _POSE_BUFFER)
-    sy = sum(p[1] for p in _POSE_BUFFER)
-    sz = sum(p[2] for p in _POSE_BUFFER)
-    syaw = sum(p[3] for p in _POSE_BUFFER)
-    return sx / n, sy / n, sz / n, syaw / n
-
-
-def read_pose_from_file() -> Optional[Tuple[float, float, float, float]]:
-    """Parse the latest pose from ``_POSE_FILE``.
-
-    The file is expected to contain four or five whitespace or comma separated
-    values ``x y z yaw [timestamp]``.  If a timestamp is provided and the entry
-    is older than ``_POSE_TIMEOUT`` seconds it will be ignored.
-    """
-
-    try:
-        with open(_POSE_FILE, 'r') as f:
-            line = f.readline().strip()
-    except FileNotFoundError:
-        logging.warning("SLAM pose file '%s' not found", _POSE_FILE)
-        return None
-    except OSError as exc:
-        logging.warning("Failed to read SLAM pose file: %s", exc)
-        return None
-
-    if not line:
-        return None
-
-    parts = [p for p in line.replace(',', ' ').split() if p]
-    if len(parts) < 4:
-        logging.warning("Malformed SLAM pose entry: '%s'", line)
-        return None
-
-    try:
-        x, y, z, yaw = map(float, parts[:4])
-    except ValueError:
-        logging.warning("Failed to parse SLAM pose: '%s'", line)
-        return None
-
-    if len(parts) >= 5:
-        try:
-            ts = float(parts[4])
-            if time.time() - ts > _POSE_TIMEOUT:
-                logging.warning("Ignoring stale SLAM pose (%.2fs old)", time.time() - ts)
-                return None
-        except ValueError:
-            logging.warning("Invalid timestamp in SLAM pose: '%s'", line)
-
-    return x, y, z, yaw
-
-
-def connect_to_slam_socket(host: str = '127.0.0.1', port: int = 30002) -> Optional[socket.socket]:
-    """Establish a non-blocking connection to a SLAM TCP socket."""
-    try:
-        sock = socket.create_connection((host, port), timeout=0.5)
-        sock.setblocking(False)
-        return sock
-    except OSError as exc:
-        logging.warning("Failed to connect to SLAM socket %s:%s - %s", host, port, exc)
-        return None
+# fallback pose if the file is missing or cannot be parsed
+_FALLBACK_POSE = (0.0, 0.0, -2.0, 0.0)
 
 
 def get_current_pose() -> Tuple[float, float, float, float]:
-    """Return the drone's current pose as ``(x, y, z, yaw)``.
+    """Return the current drone pose ``(x, y, z, yaw)``.
 
-    The function first attempts to obtain the latest pose estimate from the
-    external SLAM system via ``read_pose_from_file``.  If this fails and an
-    AirSim connection is available, the simulator's ground-truth pose is used as
-    a fallback.  Should both sources be unavailable, ``(0, 0, 0, 0)`` is
-    returned.  A short moving average smooths consecutive poses.
+    The pose is read from :data:`POSE_FILE` which must contain a single line in
+    ``x,y,z,yaw`` format.  If the file is missing or cannot be parsed a fallback
+    pose is returned.
     """
+    if not os.path.exists(POSE_FILE):
+        return _FALLBACK_POSE
 
-    pose = read_pose_from_file()
-
-    if pose is None and _CLIENT is not None:
-        try:
-            sim_pose = _CLIENT.simGetVehiclePose()
-            pose = (
-                sim_pose.position.x_val,
-                sim_pose.position.y_val,
-                sim_pose.position.z_val,
-                airsim.to_eularian_angles(sim_pose.orientation)[2],
-            )
-        except Exception as exc:  # pragma: no cover - unexpected AirSim error
-            logging.warning("Failed to retrieve AirSim pose: %s", exc)
-            pose = None
-
-    if pose is None:
-        pose = (0.0, 0.0, 0.0, 0.0)
-
-    _POSE_BUFFER.append(pose)
-    return _average_pose() if len(_POSE_BUFFER) > 1 else pose
+    try:
+        with open(POSE_FILE, "r") as f:
+            line = f.readline()
+            parts = line.strip().split(",")
+            x, y, z, yaw = map(float, parts[:4])
+            return x, y, z, yaw
+    except Exception:
+        return _FALLBACK_POSE


### PR DESCRIPTION
## Summary
- add `simulated_slam_writer.py` that writes AirSim ground truth poses to `slam/latest_pose.txt`
- simplify `slam_interface.py` to read the pose file and provide a fallback pose when unavailable

## Testing
- `python -m py_compile simulated_slam_writer.py main.py navigation/deliberative_nav.py slam/slam_interface.py uav/airsim_utils.py scripts/airsim_image_publisher.py analysis/plot_flight.py`


------
https://chatgpt.com/codex/tasks/task_e_6845d662cdd88325a79562a3031bbe51